### PR TITLE
Added ability to make a "launch project" configuration

### DIFF
--- a/lua/dap-projects.lua
+++ b/lua/dap-projects.lua
@@ -1,12 +1,11 @@
 local M = {}
 
-M.config_paths = { "./.nvim/dap.lua", "./.dap.lua", "./dap.lua" }
+M.config_paths = {"./.nvim/dap.lua", "./.dap.lua", "./dap.lua"}
 
 M.search_project_config = function()
     local status_ok, dap = pcall(require, "dap")
     if not status_ok then
-        vim.notify("[dap-projects.nvim] Could not find nvim-dap, make sure you load it before dap-projects.nvim.",
-            vim.log.levels.ERROR, nil)
+        vim.notify("[dap-projects.nvim] Could not find nvim-dap, make sure you load it before dap-projects.nvim.", vim.log.levels.ERROR, nil)
         return
     end
     local project_config = ""
@@ -27,20 +26,6 @@ M.search_project_config = function()
 
     vim.notify("[dap-projects.nvim] Found custom configuration at " .. project_config, vim.log.levels.INFO, nil)
 
-    function dump(o)
-        if type(o) == 'table' then
-            local s = '{ '
-            for k, v in pairs(o) do
-                if type(k) ~= 'number' then k = '"' .. k .. '"' end
-                s = s .. '[' .. k .. '] = ' .. dump(v) .. ','
-            end
-            return s .. '} '
-        else
-            return tostring(o)
-        end
-    end
-
-    print(dump(dap.providers))
     -- copy custom config to dap
     if config.adapters ~= nil then
         if dap.adapters ~= nil then

--- a/lua/dap-projects.lua
+++ b/lua/dap-projects.lua
@@ -1,11 +1,12 @@
 local M = {}
 
-M.config_paths = {"./.nvim/dap.lua", "./.dap.lua", "./dap.lua"}
+M.config_paths = { "./.nvim/dap.lua", "./.dap.lua", "./dap.lua" }
 
 M.search_project_config = function()
     local status_ok, dap = pcall(require, "dap")
     if not status_ok then
-        vim.notify("[dap-projects.nvim] Could not find nvim-dap, make sure you load it before dap-projects.nvim.", vim.log.levels.ERROR, nil)
+        vim.notify("[dap-projects.nvim] Could not find nvim-dap, make sure you load it before dap-projects.nvim.",
+            vim.log.levels.ERROR, nil)
         return
     end
     local project_config = ""
@@ -26,6 +27,20 @@ M.search_project_config = function()
 
     vim.notify("[dap-projects.nvim] Found custom configuration at " .. project_config, vim.log.levels.INFO, nil)
 
+    function dump(o)
+        if type(o) == 'table' then
+            local s = '{ '
+            for k, v in pairs(o) do
+                if type(k) ~= 'number' then k = '"' .. k .. '"' end
+                s = s .. '[' .. k .. '] = ' .. dump(v) .. ','
+            end
+            return s .. '} '
+        else
+            return tostring(o)
+        end
+    end
+
+    print(dump(dap.providers))
     -- copy custom config to dap
     if config.adapters ~= nil then
         if dap.adapters ~= nil then
@@ -40,6 +55,17 @@ M.search_project_config = function()
             end
         else
             dap.adapters = config.adapters
+        end
+        -- Apply overrides if necessary,
+        -- We assume there is only one entry,
+        -- since providing any more is useless
+        if config.override ~= nil then
+            local override_key = next(config.adapters, nil)
+            setmetatable(dap.adapters, {
+                __index = function(table, key)
+                    return rawget(table, override_key)
+                end
+            })
         end
     end
     if config.configurations ~= nil then
@@ -60,6 +86,15 @@ M.search_project_config = function()
             end
         else
             dap.configurations = config.configurations
+        end
+        -- Apply overrides if necessary
+        if config.override ~= nil then
+            local override_key = next(config.configurations, nil)
+            setmetatable(dap.configurations, {
+                __index = function(table, key)
+                    return rawget(table, override_key)
+                end
+            })
         end
     end
 end


### PR DESCRIPTION
TLDR: Made it so when `overwrite` is set to anything (any non-nil), it will make it so any attempt to index `configurations` or `adapters` will always return the same value, regardless of the input to the index.

Basically, I was looking for something similar to pressing F5 in VS (I'm primarily a C++ developer), but couldn't really find a way to run the same launch command regardless of which file I was currently using in nvim-dap, so I found this plugin, which is really great, I love that it's just one file, and it works great, but it still doesn't seem to allow for this functionality, so I added it myself (in a very hacky way, I've almost never used lua).

Please tell me if this functionality exists somewhere else and I'll promptly remove the PR (and update my own configuration), otherwise, I think it's a good addon for people coming from other IDEs (like VS)